### PR TITLE
do not override the retention policy + minor update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,12 @@ scalaVersion := "2.11.7"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "com.netflix.rxjava" % "rxjava-scala" % "0.18.3",
+  "com.netflix.rxjava" % "rxjava-scala" % "0.18.4",
   "ch.qos.logback" % "logback-classic" % "1.0.13",
-  "org.mongodb" %% "casbah" % "2.7.4",
-  "org.scalaz" %% "scalaz-core" % "7.1.0",
+  "org.mongodb" %% "casbah" % "2.7.5",
+  "org.scalaz" %% "scalaz-core" % "7.1.4",
   "com.typesafe" % "config" % "1.2.1",
-  "com.github.influxdb" % "influxdb-java" % "influxdb-java-2.0",
+  "org.influxdb" % "influxdb-java" % "2.0",
   "net.ceedubs" %% "ficus" % "1.1.2"
 )
 
@@ -45,6 +45,3 @@ dockerfile in docker <<= (artifactPath.in(Compile, packageBin), fullClasspath in
 }
 
 imageName in docker := ImageName(namespace = Some("tenshi"), repository = "mongo-metrics-reporter")
-
-resolvers +=
-  "JitPack.io" at "https://jitpack.io"

--- a/src/main/scala/de/commercetools/graphite/InfluxDBTest.scala
+++ b/src/main/scala/de/commercetools/graphite/InfluxDBTest.scala
@@ -25,6 +25,7 @@ object InfluxDBTest extends App {
     val points = (1 to 30).toList map { i =>
         val p = Point
           .measurement("request33")
+          .time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
           .tag("server", Random.shuffle(servers).head)
           .tag("project", "project" + Random.nextInt(10))
           .field("aa", Random.nextInt(100).toLong)
@@ -40,7 +41,6 @@ object InfluxDBTest extends App {
       .database(db)
       .retentionPolicy("default")
       .consistency(ConsistencyLevel.ALL)
-      .time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
       .build()
 
     points foreach batch.point

--- a/src/main/scala/de/commercetools/graphite/MongoInfluxDBReporter.scala
+++ b/src/main/scala/de/commercetools/graphite/MongoInfluxDBReporter.scala
@@ -205,7 +205,7 @@ class MongoInfluxDBReporter(cfg: Config) {
     val properFields = fields.toList.flatMap {case (key, value) => normalizeFn(name, tags, value) map (key -> _)}
 
     if (properFields.nonEmpty) {
-      val p = Point.measurement(name)
+      val p = Point.measurement(name).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
 
       tags foreach {case (key, value) => p.tag(key, value)}
       properFields foreach {case (key, value) => p.field(key, value + "i")}
@@ -250,9 +250,6 @@ class MongoInfluxDBReporter(cfg: Config) {
 
     val batch = BatchPoints
       .database(influxDbConfig.databaseName)
-      .retentionPolicy("default")
-      .consistency(ConsistencyLevel.ALL)
-      .time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
       .build()
 
     points foreach batch.point


### PR DESCRIPTION
This PR remove the override of retention policy and consistency. Those should be managed by default from the influxDB configuration.

Keeping forever those metric can become quite expensive  :dizzy_face:

At the same time I upgraded ```influxdb-java``` to the official artifact and bumped the minor dependency version.

Plz review @OlegIlyenko 